### PR TITLE
Doc link

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -14,11 +14,6 @@
 
 {{ cookiecutter.project_short_description}}
 
-Documentation
--------------
-
-The full documentation is at http://{{ cookiecutter.repo_name }}.rtfd.org.
-
 Quickstart
 ----------
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -31,13 +31,17 @@ class PyTest(TestCommand):
 
 
 readme = open('README.rst').read()
+doclink = """Documentation
+-------------
+
+The full documentation is at http://{{ cookiecutter.repo_name }}.rtfd.org."""
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='{{ cookiecutter.repo_name }}',
     version={{ cookiecutter.repo_name }}.__version__,
     description='{{ cookiecutter.project_short_description }}',
-    long_description=readme + '\n\n' + history,
+    long_description=readme + '\n\n' + doclink + '\n\n' + history,
     author='{{ cookiecutter.full_name }}',
     author_email='{{ cookiecutter.email }}',
     url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}',


### PR DESCRIPTION
With sphinx documentation now importing the README in the index it makes little sense to have the full documentation link there aswell.

This change will inject the full documentation link for the setup.py only making it available everywhere bar the sphinx generated documentation.
