### PR TITLE
changing the cookiecutter command arg to be the proper repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Usage
 
 Generate a Python package project::
 
-    cookiecutter https://github.com/audreyr/cookiecutter-pypackage.git
+    cookiecutter https://github.com/Nekroze/cookiecutter-pypackage.git
 
 Then:
 


### PR DESCRIPTION
Looks like the cookiecutter command you had in the README.rst pointed to audreyr repo instead of your own (assuming you want people to pull yours...)
