### PR TITLE
Remove unknown badge

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -8,10 +8,6 @@
 .. image:: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}.png?branch=master
     :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
 
-.. image:: https://pypip.in/d/{{ cookiecutter.repo_name }}/badge.png
-    :target: https://pypi.python.org/pypi/{{ cookiecutter.repo_name }}
-
-
 {{ cookiecutter.project_short_description}}
 
 


### PR DESCRIPTION
I'm not sure what https://pypip.in is, but the server's certificate doesn't work and the HTTP:// version doesn't render anything useful?